### PR TITLE
NO MRG, TST: Re-render with CircleCI 2.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+
+jobs:
+  build:
+    working_directory: ~/test
+    machine: true
+    branches:
+      ignore:
+        - /.*/
+    steps:
+      - run:
+          # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
+          command: exit 0
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore:
+                - /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ jobs:
   build:
     working_directory: ~/test
     machine: true
-    branches:
-      ignore:
-        - /.*/
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
@@ -16,8 +13,4 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build:
-          filters:
-            branches:
-              ignore:
-                - /.*/
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
   build:
     working_directory: ~/test
     machine: true
+    branches:
+      ignore:
+        - /.*/
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
@@ -13,4 +16,8 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore:
+                - /.*/

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-general:
-  branches:
-    ignore:
-      - /.*/
-
-test:
-  override:
-    # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
-    - exit 0


### PR DESCRIPTION
Please do **not** merge this PR. It is for testing purposes only.

Made changes to `conda-smithy` to try and support CircleCI 2.0's format and layout. This should make it easier to explore parallel matrix builds in the future as well. More details in PR ( https://github.com/conda-forge/conda-smithy/pull/530 ).